### PR TITLE
Part provider rewrite

### DIFF
--- a/src/main/java/io/github/faecraft/heartshapedbox/bad/BadMixinAtomicFlag.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/bad/BadMixinAtomicFlag.java
@@ -14,5 +14,5 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author P03W
  */
 public class BadMixinAtomicFlag {
-    public static AtomicBoolean callSuperDamage = new AtomicBoolean();
+    public static final AtomicBoolean callSuperDamage = new AtomicBoolean();
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/AbstractBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/AbstractBodyPart.java
@@ -36,6 +36,14 @@ public abstract class AbstractBodyPart {
         health = amount;
     }
     
+    public float getMaxHealth() {
+        return health;
+    }
+    
+    public void setMaxHealth(float amount) {
+        maxHealth = amount;
+    }
+    
     public float takeDamage(float amount) {
         if (amount > health) {
             float used = amount - health;

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/AbstractBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/AbstractBodyPart.java
@@ -17,10 +17,10 @@ public abstract class AbstractBodyPart {
     public abstract float getDefaultMaxHealth();
     
     public void toTag(CompoundTag tag) {
-        CompoundTag info = new CompoundTag();
-        info.putFloat("health", health);
-        info.putFloat("maxHealth", maxHealth);
-        tag.put(getIdentifier().toString(), info);
+        CompoundTag data = new CompoundTag();
+        data.putFloat("health", health);
+        data.putFloat("maxHealth", maxHealth);
+        tag.put(getIdentifier().toString(), data);
     }
     
     public void fromTag(CompoundTag tag) {

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/AbstractBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/AbstractBodyPart.java
@@ -37,7 +37,7 @@ public abstract class AbstractBodyPart {
     }
     
     public float getMaxHealth() {
-        return health;
+        return maxHealth;
     }
     
     public void setMaxHealth(float amount) {

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/AbstractBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/AbstractBodyPart.java
@@ -24,9 +24,8 @@ public abstract class AbstractBodyPart {
     }
     
     public void fromTag(CompoundTag tag) {
-        CompoundTag info = tag.getCompound(getIdentifier().toString());
-        health = info.getFloat("health");
-        maxHealth = info.getFloat("maxHealth");
+        health = tag.getFloat("health");
+        maxHealth = tag.getFloat("maxHealth");
     }
     
     public float getHealth() {
@@ -50,7 +49,7 @@ public abstract class AbstractBodyPart {
     @Override
     public String toString() {
         return "BodyPart(" + getIdentifier().toString() + ") {" +
-            "maxHealth=" + getDefaultMaxHealth() +
+            "maxHealth=" + maxHealth +
             ", health=" + health +
             '}';
     }

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/AbstractBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/AbstractBodyPart.java
@@ -2,26 +2,31 @@ package io.github.faecraft.heartshapedbox.body;
 
 import io.github.faecraft.heartshapedbox.math.FlexBox;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class AbstractBodyPart {
-    private float health = getMaxHealth();
+    private float maxHealth = getDefaultMaxHealth();
+    private float health = maxHealth;
     private FlexBox flexBox = FlexBox.zero();
     
-    public abstract BodyPartType getType();
+    public abstract @NotNull Identifier getIdentifier();
     
     public abstract BodyPartSide getSide();
     
-    public abstract float getMaxHealth();
+    public abstract float getDefaultMaxHealth();
     
     public void toTag(CompoundTag tag) {
         CompoundTag info = new CompoundTag();
         info.putFloat("health", health);
-        tag.put(getType().name() + " - " + getSide().name(), info);
+        info.putFloat("maxHealth", maxHealth);
+        tag.put(getIdentifier().toString(), info);
     }
     
     public void fromTag(CompoundTag tag) {
-        CompoundTag info = tag.getCompound(getType().name() + " - " + getSide().name());
+        CompoundTag info = tag.getCompound(getIdentifier().toString());
         health = info.getFloat("health");
+        maxHealth = info.getFloat("maxHealth");
     }
     
     public float getHealth() {
@@ -42,16 +47,10 @@ public abstract class AbstractBodyPart {
         return 0;
     }
     
-    public <T extends AbstractBodyPart> T copyInto(T out) {
-        out.setFlexBox(getFlexBox());
-        out.setHealth(getHealth());
-        return out;
-    }
-    
     @Override
     public String toString() {
-        return getType().name() + "-" + getSide().name() + "{" +
-            "maxHealth=" + getMaxHealth() +
+        return "BodyPart(" + getIdentifier().toString() + ") {" +
+            "maxHealth=" + getDefaultMaxHealth() +
             ", health=" + health +
             '}';
     }

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartProvider.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartProvider.java
@@ -12,9 +12,9 @@ import java.util.Optional;
 public interface BodyPartProvider {
     ArrayList<AbstractBodyPart> getParts();
     
-    CompoundTag toTag();
+    CompoundTag writeToTag();
     
-    void fromTag(CompoundTag tag);
+    void readFromTag(CompoundTag tag);
     
     Optional<AbstractBodyPart> maybeGet(Identifier identifier);
     

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartProvider.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartProvider.java
@@ -10,17 +10,9 @@ import java.util.ArrayList;
 
 // Duck, make sure to add to this for each part
 public interface BodyPartProvider {
-    HeadBodyPart getHead();
-    
-    Pair<ArmBodyPart, ArmBodyPart> getArms();
-    
-    Pair<LegBodyPart, LegBodyPart> getLegs();
-    
-    Pair<FootBodyPart, FootBodyPart> getFeet();
-    
-    ArrayList<AbstractBodyPart> getAll();
+    ArrayList<AbstractBodyPart> getParts();
     
     ArrayList<AbstractBodyPart> stateCopy();
     
-    void setFrom(ArrayList<AbstractBodyPart> provider);
+    void setStateFrom(ArrayList<AbstractBodyPart> provider);
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartProvider.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartProvider.java
@@ -16,5 +16,7 @@ public interface BodyPartProvider {
     
     void fromTag(CompoundTag tag);
     
-    Optional<AbstractBodyPart> getFromIdentifier(Identifier identifier);
+    Optional<AbstractBodyPart> maybeGet(Identifier identifier);
+    
+    AbstractBodyPart getOrThrow(Identifier identifier);
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartProvider.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartProvider.java
@@ -2,6 +2,7 @@ package io.github.faecraft.heartshapedbox.body;
 
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -17,6 +18,8 @@ public interface BodyPartProvider {
     void readFromTag(CompoundTag tag);
     
     Optional<AbstractBodyPart> maybeGet(Identifier identifier);
+    
+    @Nullable AbstractBodyPart getOrNull(Identifier identifier);
     
     AbstractBodyPart getOrThrow(Identifier identifier);
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartProvider.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartProvider.java
@@ -5,12 +5,15 @@ import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Optional;
 
 /**
  * Duck, applied in BodyPartDuck mixin
  */
 public interface BodyPartProvider {
+    HashMap<Identifier, AbstractBodyPart> getPartsMap();
+    
     ArrayList<AbstractBodyPart> getParts();
     
     CompoundTag writeToTag();

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartProvider.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartProvider.java
@@ -1,18 +1,18 @@
 package io.github.faecraft.heartshapedbox.body;
 
-import io.github.faecraft.heartshapedbox.body.impl.ArmBodyPart;
-import io.github.faecraft.heartshapedbox.body.impl.FootBodyPart;
-import io.github.faecraft.heartshapedbox.body.impl.HeadBodyPart;
-import io.github.faecraft.heartshapedbox.body.impl.LegBodyPart;
-import net.minecraft.util.Pair;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.Identifier;
 
 import java.util.ArrayList;
+import java.util.Optional;
 
 // Duck, make sure to add to this for each part
 public interface BodyPartProvider {
     ArrayList<AbstractBodyPart> getParts();
     
-    ArrayList<AbstractBodyPart> stateCopy();
+    CompoundTag toTag();
     
-    void setStateFrom(ArrayList<AbstractBodyPart> provider);
+    void fromTag(CompoundTag tag);
+    
+    Optional<AbstractBodyPart> getFromIdentifier(Identifier identifier);
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartProvider.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartProvider.java
@@ -6,7 +6,9 @@ import net.minecraft.util.Identifier;
 import java.util.ArrayList;
 import java.util.Optional;
 
-// Duck, make sure to add to this for each part
+/**
+ * Duck, applied in BodyPartDuck mixin
+ */
 public interface BodyPartProvider {
     ArrayList<AbstractBodyPart> getParts();
     

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartSide.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartSide.java
@@ -1,7 +1,18 @@
 package io.github.faecraft.heartshapedbox.body;
 
-public enum BodyPartSide {
+import java.util.Locale;
+
+interface lowerCaseEnumName {
+    String lowerName();
+}
+
+public enum BodyPartSide implements lowerCaseEnumName {
     CENTER,
     LEFT,
-    RIGHT
+    RIGHT;
+    
+    @Override
+    public String lowerName() {
+        return name().toLowerCase(Locale.ROOT);
+    }
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartType.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/BodyPartType.java
@@ -1,9 +1,0 @@
-package io.github.faecraft.heartshapedbox.body;
-
-public enum BodyPartType {
-    FEET,
-    LEGS,
-    ARMS,
-    HEAD
-}
-

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/BuiltInParts.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/BuiltInParts.java
@@ -16,16 +16,16 @@ public class BuiltInParts {
     public static final Identifier HEAD = new Identifier("hsb:head");
     
     // Arms
-    public static final Identifier LEFT_ARM = new Identifier("hsb:arm/" + LEFT.name().toLowerCase(Locale.ROOT));
-    public static final Identifier RIGHT_ARM = new Identifier("hsb:arm/" + RIGHT.name().toLowerCase(Locale.ROOT));
+    public static final Identifier LEFT_ARM = new Identifier("hsb:arm/" + LEFT.lowerName());
+    public static final Identifier RIGHT_ARM = new Identifier("hsb:arm/" + RIGHT.lowerName());
     
     // Legs
-    public static final Identifier LEFT_LEG = new Identifier("hsb:leg/" + LEFT.name().toLowerCase(Locale.ROOT));
-    public static final Identifier RIGHT_LEG = new Identifier("hsb:leg/" + RIGHT.name().toLowerCase(Locale.ROOT));
+    public static final Identifier LEFT_LEG = new Identifier("hsb:leg/" + LEFT.lowerName());
+    public static final Identifier RIGHT_LEG = new Identifier("hsb:leg/" + RIGHT.lowerName());
     
     // Feet
-    public static final Identifier LEFT_FOOT = new Identifier("hsb:foot/" + LEFT.name().toLowerCase(Locale.ROOT));
-    public static final Identifier RIGHT_FOOT = new Identifier("hsb:foot/" + RIGHT.name().toLowerCase(Locale.ROOT));
+    public static final Identifier LEFT_FOOT = new Identifier("hsb:foot/" + LEFT.lowerName());
+    public static final Identifier RIGHT_FOOT = new Identifier("hsb:foot/" + RIGHT.lowerName());
     
     
     // Pairs

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/BuiltInParts.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/BuiltInParts.java
@@ -1,0 +1,53 @@
+package io.github.faecraft.heartshapedbox.body;
+
+import io.github.faecraft.heartshapedbox.body.impl.ArmBodyPart;
+import io.github.faecraft.heartshapedbox.body.impl.FootBodyPart;
+import io.github.faecraft.heartshapedbox.body.impl.LegBodyPart;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Pair;
+
+import java.util.Locale;
+
+import static io.github.faecraft.heartshapedbox.body.BodyPartSide.LEFT;
+import static io.github.faecraft.heartshapedbox.body.BodyPartSide.RIGHT;
+
+public class BuiltInParts {
+    // Head
+    public static final Identifier HEAD = new Identifier("hsb:head");
+    
+    // Arms
+    public static final Identifier LEFT_ARM = new Identifier("hsb:arm/" + LEFT.name().toLowerCase(Locale.ROOT));
+    public static final Identifier RIGHT_ARM = new Identifier("hsb:arm/" + RIGHT.name().toLowerCase(Locale.ROOT));
+    
+    // Legs
+    public static final Identifier LEFT_LEG = new Identifier("hsb:leg/" + LEFT.name().toLowerCase(Locale.ROOT));
+    public static final Identifier RIGHT_LEG = new Identifier("hsb:leg/" + RIGHT.name().toLowerCase(Locale.ROOT));
+    
+    // Feet
+    public static final Identifier LEFT_FOOT = new Identifier("hsb:foot/" + LEFT.name().toLowerCase(Locale.ROOT));
+    public static final Identifier RIGHT_FOOT = new Identifier("hsb:foot/" + RIGHT.name().toLowerCase(Locale.ROOT));
+    
+    
+    // Pairs
+    
+    public static Pair<ArmBodyPart, ArmBodyPart> getArms(BodyPartProvider provider) {
+        return new Pair<>(
+            (ArmBodyPart)provider.getOrThrow(BuiltInParts.LEFT_ARM),
+            (ArmBodyPart)provider.getOrThrow(BuiltInParts.RIGHT_ARM)
+        );
+    }
+    
+    public static Pair<LegBodyPart, LegBodyPart> getLegs(BodyPartProvider provider) {
+        return new Pair<>(
+            (LegBodyPart)provider.getOrThrow(BuiltInParts.LEFT_LEG),
+            (LegBodyPart)provider.getOrThrow(BuiltInParts.RIGHT_LEG)
+        );
+    }
+    
+    public static Pair<FootBodyPart, FootBodyPart> getFeet(BodyPartProvider provider) {
+        return new Pair<>(
+            (FootBodyPart)provider.getOrThrow(BuiltInParts.LEFT_FOOT),
+            (FootBodyPart)provider.getOrThrow(BuiltInParts.RIGHT_FOOT)
+        );
+    }
+}

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/BuiltInParts.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/BuiltInParts.java
@@ -6,8 +6,6 @@ import io.github.faecraft.heartshapedbox.body.impl.LegBodyPart;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Pair;
 
-import java.util.Locale;
-
 import static io.github.faecraft.heartshapedbox.body.BodyPartSide.LEFT;
 import static io.github.faecraft.heartshapedbox.body.BodyPartSide.RIGHT;
 

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/BuiltInParts.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/BuiltInParts.java
@@ -8,22 +8,23 @@ import net.minecraft.util.Pair;
 
 import static io.github.faecraft.heartshapedbox.body.BodyPartSide.LEFT;
 import static io.github.faecraft.heartshapedbox.body.BodyPartSide.RIGHT;
+import static io.github.faecraft.heartshapedbox.main.HSBMain.MOD_ID;
 
 public class BuiltInParts {
     // Head
-    public static final Identifier HEAD = new Identifier("hsb:head");
+    public static final Identifier HEAD = new Identifier(MOD_ID, "head");
     
     // Arms
-    public static final Identifier LEFT_ARM = new Identifier("hsb:arm/" + LEFT.lowerName());
-    public static final Identifier RIGHT_ARM = new Identifier("hsb:arm/" + RIGHT.lowerName());
+    public static final Identifier LEFT_ARM = new Identifier(MOD_ID, "arm/" + LEFT.lowerName());
+    public static final Identifier RIGHT_ARM = new Identifier(MOD_ID, "arm/" + RIGHT.lowerName());
     
     // Legs
-    public static final Identifier LEFT_LEG = new Identifier("hsb:leg/" + LEFT.lowerName());
-    public static final Identifier RIGHT_LEG = new Identifier("hsb:leg/" + RIGHT.lowerName());
+    public static final Identifier LEFT_LEG = new Identifier(MOD_ID, "leg/" + LEFT.lowerName());
+    public static final Identifier RIGHT_LEG = new Identifier(MOD_ID, "leg/" + RIGHT.lowerName());
     
     // Feet
-    public static final Identifier LEFT_FOOT = new Identifier("hsb:foot/" + LEFT.lowerName());
-    public static final Identifier RIGHT_FOOT = new Identifier("hsb:foot/" + RIGHT.lowerName());
+    public static final Identifier LEFT_FOOT = new Identifier(MOD_ID, "foot/" + LEFT.lowerName());
+    public static final Identifier RIGHT_FOOT = new Identifier(MOD_ID, "foot/" + RIGHT.lowerName());
     
     
     // Pairs

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/impl/ArmBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/impl/ArmBodyPart.java
@@ -2,6 +2,7 @@ package io.github.faecraft.heartshapedbox.body.impl;
 
 import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
 import io.github.faecraft.heartshapedbox.body.BodyPartSide;
+import io.github.faecraft.heartshapedbox.body.BuiltInParts;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,7 +12,7 @@ public class ArmBodyPart extends AbstractBodyPart {
     
     public ArmBodyPart(BodyPartSide side) {
         this.side = side;
-        this.identifier = new Identifier("hsb:arm/" + side.lowerName());
+        this.identifier = side == BodyPartSide.LEFT ? BuiltInParts.LEFT_ARM : BuiltInParts.RIGHT_ARM;
     }
     
     @Override

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/impl/ArmBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/impl/ArmBodyPart.java
@@ -5,8 +5,6 @@ import io.github.faecraft.heartshapedbox.body.BodyPartSide;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Locale;
-
 public class ArmBodyPart extends AbstractBodyPart {
     private final BodyPartSide side;
     private final Identifier identifier;

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/impl/ArmBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/impl/ArmBodyPart.java
@@ -13,7 +13,7 @@ public class ArmBodyPart extends AbstractBodyPart {
     
     public ArmBodyPart(BodyPartSide side) {
         this.side = side;
-        this.identifier = new Identifier("hsb:arm/" + side.name().toLowerCase(Locale.ROOT));
+        this.identifier = new Identifier("hsb:arm/" + side.lowerName());
     }
     
     @Override

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/impl/ArmBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/impl/ArmBodyPart.java
@@ -2,18 +2,23 @@ package io.github.faecraft.heartshapedbox.body.impl;
 
 import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
 import io.github.faecraft.heartshapedbox.body.BodyPartSide;
-import io.github.faecraft.heartshapedbox.body.BodyPartType;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Locale;
 
 public class ArmBodyPart extends AbstractBodyPart {
     private final BodyPartSide side;
+    private final Identifier identifier;
     
     public ArmBodyPart(BodyPartSide side) {
         this.side = side;
+        this.identifier = new Identifier("hsb:arm/" + side.name().toLowerCase(Locale.ROOT));
     }
     
     @Override
-    public BodyPartType getType() {
-        return BodyPartType.ARMS;
+    public @NotNull Identifier getIdentifier() {
+        return identifier;
     }
     
     @Override
@@ -22,7 +27,7 @@ public class ArmBodyPart extends AbstractBodyPart {
     }
     
     @Override
-    public float getMaxHealth() {
+    public float getDefaultMaxHealth() {
         return 3;
     }
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/impl/FootBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/impl/FootBodyPart.java
@@ -13,7 +13,7 @@ public class FootBodyPart extends AbstractBodyPart {
     
     public FootBodyPart(BodyPartSide side) {
         this.side = side;
-        this.identifier = new Identifier("hsb:foot/" + side.name().toLowerCase(Locale.ROOT));
+        this.identifier = new Identifier("hsb:foot/" + side.lowerName());
     }
     
     @Override

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/impl/FootBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/impl/FootBodyPart.java
@@ -2,6 +2,7 @@ package io.github.faecraft.heartshapedbox.body.impl;
 
 import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
 import io.github.faecraft.heartshapedbox.body.BodyPartSide;
+import io.github.faecraft.heartshapedbox.body.BuiltInParts;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,7 +12,7 @@ public class FootBodyPart extends AbstractBodyPart {
     
     public FootBodyPart(BodyPartSide side) {
         this.side = side;
-        this.identifier = new Identifier("hsb:foot/" + side.lowerName());
+        this.identifier = side == BodyPartSide.LEFT ? BuiltInParts.LEFT_FOOT : BuiltInParts.RIGHT_FOOT;
     }
     
     @Override

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/impl/FootBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/impl/FootBodyPart.java
@@ -2,18 +2,23 @@ package io.github.faecraft.heartshapedbox.body.impl;
 
 import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
 import io.github.faecraft.heartshapedbox.body.BodyPartSide;
-import io.github.faecraft.heartshapedbox.body.BodyPartType;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Locale;
 
 public class FootBodyPart extends AbstractBodyPart {
     private final BodyPartSide side;
+    private final Identifier identifier;
     
     public FootBodyPart(BodyPartSide side) {
         this.side = side;
+        this.identifier = new Identifier("hsb:foot/" + side.name().toLowerCase(Locale.ROOT));
     }
     
     @Override
-    public BodyPartType getType() {
-        return BodyPartType.FEET;
+    public @NotNull Identifier getIdentifier() {
+        return identifier;
     }
     
     @Override
@@ -22,7 +27,7 @@ public class FootBodyPart extends AbstractBodyPart {
     }
     
     @Override
-    public float getMaxHealth() {
+    public float getDefaultMaxHealth() {
         return 2;
     }
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/impl/FootBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/impl/FootBodyPart.java
@@ -5,8 +5,6 @@ import io.github.faecraft.heartshapedbox.body.BodyPartSide;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Locale;
-
 public class FootBodyPart extends AbstractBodyPart {
     private final BodyPartSide side;
     private final Identifier identifier;

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/impl/HeadBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/impl/HeadBodyPart.java
@@ -2,11 +2,12 @@ package io.github.faecraft.heartshapedbox.body.impl;
 
 import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
 import io.github.faecraft.heartshapedbox.body.BodyPartSide;
+import io.github.faecraft.heartshapedbox.body.BuiltInParts;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.NotNull;
 
 public class HeadBodyPart extends AbstractBodyPart {
-    private final Identifier identifier = new Identifier("hsb:head");
+    private final Identifier identifier = BuiltInParts.HEAD;
     
     @Override
     public @NotNull Identifier getIdentifier() {

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/impl/HeadBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/impl/HeadBodyPart.java
@@ -2,23 +2,24 @@ package io.github.faecraft.heartshapedbox.body.impl;
 
 import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
 import io.github.faecraft.heartshapedbox.body.BodyPartSide;
-import io.github.faecraft.heartshapedbox.body.BodyPartType;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.NotNull;
 
 public class HeadBodyPart extends AbstractBodyPart {
-    private final BodyPartSide side = BodyPartSide.CENTER;
+    private final Identifier identifier = new Identifier("hsb:head");
     
     @Override
-    public BodyPartType getType() {
-        return BodyPartType.HEAD;
+    public @NotNull Identifier getIdentifier() {
+        return identifier;
     }
     
     @Override
     public BodyPartSide getSide() {
-        return side;
+        return BodyPartSide.CENTER;
     }
     
     @Override
-    public float getMaxHealth() {
+    public float getDefaultMaxHealth() {
         return 6;
     }
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/impl/LegBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/impl/LegBodyPart.java
@@ -2,18 +2,23 @@ package io.github.faecraft.heartshapedbox.body.impl;
 
 import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
 import io.github.faecraft.heartshapedbox.body.BodyPartSide;
-import io.github.faecraft.heartshapedbox.body.BodyPartType;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Locale;
 
 public class LegBodyPart extends AbstractBodyPart {
     private final BodyPartSide side;
+    private final Identifier identifier;
     
     public LegBodyPart(BodyPartSide side) {
         this.side = side;
+        this.identifier = new Identifier("hsb:leg/" + side.name().toLowerCase(Locale.ROOT));
     }
     
     @Override
-    public BodyPartType getType() {
-        return BodyPartType.LEGS;
+    public @NotNull Identifier getIdentifier() {
+        return identifier;
     }
     
     @Override
@@ -22,7 +27,7 @@ public class LegBodyPart extends AbstractBodyPart {
     }
     
     @Override
-    public float getMaxHealth() {
+    public float getDefaultMaxHealth() {
         return 3;
     }
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/impl/LegBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/impl/LegBodyPart.java
@@ -5,8 +5,6 @@ import io.github.faecraft.heartshapedbox.body.BodyPartSide;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Locale;
-
 public class LegBodyPart extends AbstractBodyPart {
     private final BodyPartSide side;
     private final Identifier identifier;

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/impl/LegBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/impl/LegBodyPart.java
@@ -13,7 +13,7 @@ public class LegBodyPart extends AbstractBodyPart {
     
     public LegBodyPart(BodyPartSide side) {
         this.side = side;
-        this.identifier = new Identifier("hsb:leg/" + side.name().toLowerCase(Locale.ROOT));
+        this.identifier = new Identifier("hsb:leg/" + side.lowerName());
     }
     
     @Override

--- a/src/main/java/io/github/faecraft/heartshapedbox/body/impl/LegBodyPart.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/body/impl/LegBodyPart.java
@@ -2,6 +2,7 @@ package io.github.faecraft.heartshapedbox.body.impl;
 
 import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
 import io.github.faecraft.heartshapedbox.body.BodyPartSide;
+import io.github.faecraft.heartshapedbox.body.BuiltInParts;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,7 +12,7 @@ public class LegBodyPart extends AbstractBodyPart {
     
     public LegBodyPart(BodyPartSide side) {
         this.side = side;
-        this.identifier = new Identifier("hsb:leg/" + side.lowerName());
+        this.identifier = side == BodyPartSide.LEFT ? BuiltInParts.LEFT_LEG : BuiltInParts.RIGHT_LEG;
     }
     
     @Override

--- a/src/main/java/io/github/faecraft/heartshapedbox/logic/HSBMiscLogic.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/logic/HSBMiscLogic.java
@@ -2,7 +2,6 @@ package io.github.faecraft.heartshapedbox.logic;
 
 import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
 import io.github.faecraft.heartshapedbox.body.BodyPartProvider;
-import io.github.faecraft.heartshapedbox.body.BodyPartSide;
 import io.github.faecraft.heartshapedbox.body.BuiltInParts;
 import io.github.faecraft.heartshapedbox.body.impl.ArmBodyPart;
 import io.github.faecraft.heartshapedbox.body.impl.FootBodyPart;

--- a/src/main/java/io/github/faecraft/heartshapedbox/logic/HSBMiscLogic.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/logic/HSBMiscLogic.java
@@ -2,6 +2,8 @@ package io.github.faecraft.heartshapedbox.logic;
 
 import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
 import io.github.faecraft.heartshapedbox.body.BodyPartProvider;
+import io.github.faecraft.heartshapedbox.body.BodyPartSide;
+import io.github.faecraft.heartshapedbox.body.BuiltInParts;
 import io.github.faecraft.heartshapedbox.body.impl.ArmBodyPart;
 import io.github.faecraft.heartshapedbox.body.impl.FootBodyPart;
 import io.github.faecraft.heartshapedbox.body.impl.HeadBodyPart;
@@ -38,14 +40,14 @@ public class HSBMiscLogic {
         Vec2f[] rightSet = results.getRight();
         
         // Feet
-        provider.getFeet().getLeft().setFlexBox(new FlexBox(
+        provider.getOrThrow(BuiltInParts.LEFT_FOOT).setFlexBox(new FlexBox(
             v3FromV2(leftSet[0], pos.y),
             v3FromV2(leftSet[1], pos.y),
             v3FromV2(leftSet[2], pos.y),
             v3FromV2(leftSet[3], pos.y),
             0.2
         ));
-        provider.getFeet().getRight().setFlexBox(new FlexBox(
+        provider.getOrThrow(BuiltInParts.RIGHT_FOOT).setFlexBox(new FlexBox(
             v3FromV2(rightSet[0], pos.y),
             v3FromV2(rightSet[1], pos.y),
             v3FromV2(rightSet[2], pos.y),
@@ -54,14 +56,14 @@ public class HSBMiscLogic {
         ));
     
         // Legs
-        provider.getLegs().getLeft().setFlexBox(new FlexBox(
+        provider.getOrThrow(BuiltInParts.LEFT_LEG).setFlexBox(new FlexBox(
             v3FromV2(leftSet[0], pos.y + 0.2),
             v3FromV2(leftSet[1], pos.y + 0.2),
             v3FromV2(leftSet[2], pos.y + 0.2),
             v3FromV2(leftSet[3], pos.y + 0.2),
             0.6
         ));
-        provider.getLegs().getRight().setFlexBox(new FlexBox(
+        provider.getOrThrow(BuiltInParts.RIGHT_LEG).setFlexBox(new FlexBox(
             v3FromV2(rightSet[0], pos.y + 0.2),
             v3FromV2(rightSet[1], pos.y + 0.2),
             v3FromV2(rightSet[2], pos.y + 0.2),
@@ -70,14 +72,14 @@ public class HSBMiscLogic {
         ));
     
         // Arms
-        provider.getArms().getLeft().setFlexBox(new FlexBox(
+        provider.getOrThrow(BuiltInParts.LEFT_ARM).setFlexBox(new FlexBox(
             v3FromV2(leftSet[0], pos.y + 0.2 + 0.6),
             v3FromV2(leftSet[1], pos.y + 0.2 + 0.6),
             v3FromV2(leftSet[2], pos.y + 0.2 + 0.6),
             v3FromV2(leftSet[3], pos.y + 0.2 + 0.6),
             0.8
         ));
-        provider.getArms().getRight().setFlexBox(new FlexBox(
+        provider.getOrThrow(BuiltInParts.RIGHT_ARM).setFlexBox(new FlexBox(
             v3FromV2(rightSet[0], pos.y + 0.2 + 0.6),
             v3FromV2(rightSet[1], pos.y + 0.2 + 0.6),
             v3FromV2(rightSet[2], pos.y + 0.2 + 0.6),
@@ -86,7 +88,7 @@ public class HSBMiscLogic {
         ));
         
         // Head
-        provider.getHead().setFlexBox(new FlexBox(
+        provider.getOrThrow(BuiltInParts.HEAD).setFlexBox(new FlexBox(
             v3FromV2(leftSet[2], pos.y + 0.2 + 0.6 + 0.8),
             v3FromV2(leftSet[1], pos.y + 0.2 + 0.6 + 0.8),
             v3FromV2(rightSet[1], pos.y + 0.2 + 0.6 + 0.8),
@@ -100,8 +102,8 @@ public class HSBMiscLogic {
         
         // Check for broken legs/feet
         // Each broken part adds a slowness level
-        Pair<LegBodyPart, LegBodyPart> legs = provider.getLegs();
-        Pair<FootBodyPart, FootBodyPart> feet = provider.getFeet();
+        Pair<LegBodyPart, LegBodyPart> legs = BuiltInParts.getLegs(provider);
+        Pair<FootBodyPart, FootBodyPart> feet = BuiltInParts.getFeet(provider);
         int slowAmp = -1;
         
         if (legs.getLeft().getHealth() <= 0) slowAmp++;
@@ -115,7 +117,7 @@ public class HSBMiscLogic {
         
         // Check for broken arms
         // Each broken one adds a mining fatigue level
-        Pair<ArmBodyPart, ArmBodyPart> arms = provider.getArms();
+        Pair<ArmBodyPart, ArmBodyPart> arms = BuiltInParts.getArms(provider);
         int fatigueAmp = -1;
         if (arms.getLeft().getHealth() <= 0) fatigueAmp++;
         if (arms.getRight().getHealth() <= 0) fatigueAmp++;
@@ -123,9 +125,9 @@ public class HSBMiscLogic {
             playerEntity.addStatusEffect(new StatusEffectInstance(StatusEffects.MINING_FATIGUE, 2, fatigueAmp, true, true));
         }
         
-        // Check for broken(? is it broken or just injured lol) head
         // Blindness and nausea if broken
-        HeadBodyPart head = provider.getHead();
+        // TODO: Kill if broken, effects come sooner(?)
+        HeadBodyPart head = (HeadBodyPart)provider.getOrThrow(BuiltInParts.HEAD);
         if (head.getHealth() <= 0) {
             // Causes rapid strobing at ~23->~10, be careful!
             playerEntity.addStatusEffect(new StatusEffectInstance(StatusEffects.BLINDNESS, 25, 0, true, true));

--- a/src/main/java/io/github/faecraft/heartshapedbox/logic/damage/DamageHandlerDispatcher.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/logic/damage/DamageHandlerDispatcher.java
@@ -1,11 +1,10 @@
 package io.github.faecraft.heartshapedbox.logic.damage;
 
 import io.github.faecraft.heartshapedbox.bad.BadMixinAtomicFlag;
-import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
-import io.github.faecraft.heartshapedbox.logic.damage.impl.*;
 import io.github.faecraft.heartshapedbox.body.BodyPartProvider;
-import net.minecraft.entity.LivingEntity;
+import io.github.faecraft.heartshapedbox.logic.damage.impl.*;
 import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Pair;
 
@@ -19,7 +18,7 @@ public class DamageHandlerDispatcher {
         for (DamageHandler possibleHandler : handlers) {
             if (possibleHandler.shouldHandle(source)) {
                 // Save a stateCopy of the provider if we want to revert
-                ArrayList<AbstractBodyPart> stateBefore = provider.stateCopy();
+                CompoundTag stateBefore = provider.toTag();
                 
                 Pair<Boolean, Float> result = possibleHandler.handleDamage(player, (BodyPartProvider)player, source, amount);
                 
@@ -30,7 +29,7 @@ public class DamageHandlerDispatcher {
                 
                 // Revert the state if vanilla doesn't like our damage for whatever reason
                 if (!didDealDamage) {
-                    provider.setFrom(stateBefore);
+                    provider.fromTag(stateBefore);
                 }
                 
                 if (result.getLeft() || amount - result.getRight() <= 0) {

--- a/src/main/java/io/github/faecraft/heartshapedbox/logic/damage/DamageHandlerDispatcher.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/logic/damage/DamageHandlerDispatcher.java
@@ -18,7 +18,7 @@ public class DamageHandlerDispatcher {
         for (DamageHandler possibleHandler : handlers) {
             if (possibleHandler.shouldHandle(source)) {
                 // Save a stateCopy of the provider if we want to revert
-                CompoundTag stateBefore = provider.toTag();
+                CompoundTag stateBefore = provider.writeToTag();
                 
                 Pair<Boolean, Float> result = possibleHandler.handleDamage(player, (BodyPartProvider)player, source, amount);
                 
@@ -29,7 +29,7 @@ public class DamageHandlerDispatcher {
                 
                 // Revert the state if vanilla doesn't like our damage for whatever reason
                 if (!didDealDamage) {
-                    provider.fromTag(stateBefore);
+                    provider.readFromTag(stateBefore);
                 }
                 
                 if (result.getLeft() || amount - result.getRight() <= 0) {

--- a/src/main/java/io/github/faecraft/heartshapedbox/logic/damage/impl/FallDamageHandler.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/logic/damage/impl/FallDamageHandler.java
@@ -1,6 +1,7 @@
 package io.github.faecraft.heartshapedbox.logic.damage.impl;
 
 import io.github.faecraft.heartshapedbox.body.BodyPartProvider;
+import io.github.faecraft.heartshapedbox.body.BuiltInParts;
 import io.github.faecraft.heartshapedbox.logic.HSBMiscLogic;
 import io.github.faecraft.heartshapedbox.logic.damage.DamageHandler;
 import net.minecraft.entity.damage.DamageSource;
@@ -16,8 +17,8 @@ public class FallDamageHandler implements DamageHandler {
     @Override
     public Pair<Boolean, Float> handleDamage(ServerPlayerEntity player, BodyPartProvider provider, DamageSource source, float amount) {
         return new Pair<>(false, HSBMiscLogic.dealDamageToPair(
-            provider.getLegs(),
-            HSBMiscLogic.dealDamageToPair(provider.getFeet(), amount)
+            BuiltInParts.getLegs(provider),
+            HSBMiscLogic.dealDamageToPair(BuiltInParts.getFeet(provider), amount)
         ));
     }
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/logic/damage/impl/FallingBlockDamageHandler.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/logic/damage/impl/FallingBlockDamageHandler.java
@@ -1,6 +1,7 @@
 package io.github.faecraft.heartshapedbox.logic.damage.impl;
 
 import io.github.faecraft.heartshapedbox.body.BodyPartProvider;
+import io.github.faecraft.heartshapedbox.body.BuiltInParts;
 import io.github.faecraft.heartshapedbox.logic.damage.DamageHandler;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -14,6 +15,6 @@ public class FallingBlockDamageHandler implements DamageHandler {
     
     @Override
     public Pair<Boolean, Float> handleDamage(ServerPlayerEntity player, BodyPartProvider provider, DamageSource source, float amount) {
-        return new Pair<>(false, provider.getHead().takeDamage(amount));
+        return new Pair<>(false, provider.getOrThrow(BuiltInParts.HEAD).takeDamage(amount));
     }
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/logic/damage/impl/GenericDamageHandler.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/logic/damage/impl/GenericDamageHandler.java
@@ -18,7 +18,7 @@ public class GenericDamageHandler implements DamageHandler {
     
     @Override
     public Pair<Boolean, Float> handleDamage(ServerPlayerEntity player, BodyPartProvider provider, DamageSource source, float amount) {
-        ArrayList<AbstractBodyPart> parts = provider.getAll();
+        ArrayList<AbstractBodyPart> parts = provider.getParts();
         
         float dealt;
         float cap = 30;

--- a/src/main/java/io/github/faecraft/heartshapedbox/logic/damage/impl/HotFloorDamageHandler.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/logic/damage/impl/HotFloorDamageHandler.java
@@ -1,6 +1,7 @@
 package io.github.faecraft.heartshapedbox.logic.damage.impl;
 
 import io.github.faecraft.heartshapedbox.body.BodyPartProvider;
+import io.github.faecraft.heartshapedbox.body.BuiltInParts;
 import io.github.faecraft.heartshapedbox.logic.HSBMiscLogic;
 import io.github.faecraft.heartshapedbox.logic.damage.DamageHandler;
 import net.minecraft.entity.damage.DamageSource;
@@ -15,6 +16,6 @@ public class HotFloorDamageHandler implements DamageHandler {
     
     @Override
     public Pair<Boolean, Float> handleDamage(ServerPlayerEntity player, BodyPartProvider provider, DamageSource source, float amount) {
-        return new Pair<>(false, HSBMiscLogic.dealDamageToPair(provider.getFeet(), amount));
+        return new Pair<>(false, HSBMiscLogic.dealDamageToPair(BuiltInParts.getFeet(provider), amount));
     }
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/logic/damage/impl/ProjectileDamageHandler.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/logic/damage/impl/ProjectileDamageHandler.java
@@ -24,7 +24,7 @@ public class ProjectileDamageHandler implements DamageHandler {
         //noinspection ConstantConditions
         Ray ray = new Ray(source.getAttacker().getPos(), source.getAttacker().getVelocity());
     
-        ArrayList<AbstractBodyPart> possible = provider.getAll();
+        ArrayList<AbstractBodyPart> possible = provider.getParts();
         possible.sort(Comparator.comparingDouble(o -> o.getFlexBox().roughCenter.distanceTo(ray.start.add(ray.direction))));
         
         for (AbstractBodyPart limb : possible) {

--- a/src/main/java/io/github/faecraft/heartshapedbox/main/HSBMain.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/main/HSBMain.java
@@ -68,7 +68,7 @@ public class HSBMain implements ModInitializer {
                         BodyPartProvider provider = (BodyPartProvider)context.getSource().getPlayer();
                         
                         for (AbstractBodyPart limb : provider.getAll()) {
-                            limb.setHealth(limb.getMaxHealth());
+                            limb.setHealth(limb.getDefaultMaxHealth());
                         }
                         
                         source.sendFeedback(new LiteralText("Reset health"), false);

--- a/src/main/java/io/github/faecraft/heartshapedbox/main/HSBMain.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/main/HSBMain.java
@@ -1,5 +1,6 @@
 package io.github.faecraft.heartshapedbox.main;
 
+import io.github.faecraft.heartshapedbox.body.BuiltInParts;
 import io.github.faecraft.heartshapedbox.body.impl.ArmBodyPart;
 import io.github.faecraft.heartshapedbox.body.impl.FootBodyPart;
 import io.github.faecraft.heartshapedbox.body.impl.HeadBodyPart;
@@ -44,21 +45,21 @@ public class HSBMain implements ModInitializer {
                     BodyPartProvider provider = (BodyPartProvider)context.getSource().getPlayer();
                     
                     source.sendFeedback(new LiteralText("Head"), false);
-                    HeadBodyPart head = provider.getHead();
+                    HeadBodyPart head = (HeadBodyPart)provider.getOrThrow(BuiltInParts.HEAD);
                     source.sendFeedback(new LiteralText("- CENTER: " + head.getHealth()), false);
                     
                     source.sendFeedback(new LiteralText("Arms"), false);
-                    Pair<ArmBodyPart, ArmBodyPart> arms = provider.getArms();
+                    Pair<ArmBodyPart, ArmBodyPart> arms = BuiltInParts.getArms(provider);
                     source.sendFeedback(new LiteralText("- LEFT: " + arms.getLeft().getHealth()), false);
                     source.sendFeedback(new LiteralText("- RIGHT: " + arms.getRight().getHealth()), false);
                     
                     source.sendFeedback(new LiteralText("Legs"), false);
-                    Pair<LegBodyPart, LegBodyPart> legs = provider.getLegs();
+                    Pair<LegBodyPart, LegBodyPart> legs = BuiltInParts.getLegs(provider);
                     source.sendFeedback(new LiteralText("- LEFT: " + legs.getLeft().getHealth()), false);
                     source.sendFeedback(new LiteralText("- RIGHT: " + legs.getRight().getHealth()), false);
                     
                     source.sendFeedback(new LiteralText("Feet"), false);
-                    Pair<FootBodyPart, FootBodyPart> feet = provider.getFeet();
+                    Pair<FootBodyPart, FootBodyPart> feet = BuiltInParts.getFeet(provider);
                     source.sendFeedback(new LiteralText("- LEFT: " + feet.getLeft().getHealth()), false);
                     source.sendFeedback(new LiteralText("- RIGHT: " + feet.getRight().getHealth()), false);
                     return 1;

--- a/src/main/java/io/github/faecraft/heartshapedbox/main/HSBMain.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/main/HSBMain.java
@@ -28,11 +28,7 @@ public class HSBMain implements ModInitializer {
         
         ServerTickEvents.END_SERVER_TICK.register(minecraftServer -> {
                 // Update FlexBoxes
-                try {
-                    PlayerLookup.all(minecraftServer).forEach(HSBMiscLogic::updatePlayerFlexBoxes);
-                } catch (IllegalStateException e) {
-                    e.printStackTrace();
-                }
+                PlayerLookup.all(minecraftServer).forEach(HSBMiscLogic::updatePlayerFlexBoxes);
                 // Debuff all players accordingly
                 PlayerLookup.all(minecraftServer).forEach(HSBMiscLogic::debuffPlayer);
             }
@@ -46,24 +42,14 @@ public class HSBMain implements ModInitializer {
                     ServerCommandSource source = context.getSource();
                     BodyPartProvider provider = (BodyPartProvider)context.getSource().getPlayer();
                     
-                    source.sendFeedback(new LiteralText("Head"), false);
-                    HeadBodyPart head = (HeadBodyPart)provider.getOrThrow(BuiltInParts.HEAD);
-                    source.sendFeedback(new LiteralText("- CENTER: " + head.getHealth()), false);
+                    for (AbstractBodyPart part : provider.getParts()) {
+                        source.sendFeedback(
+                            new LiteralText(part.getIdentifier().toString())
+                                .append(new LiteralText(" - "))
+                                .append(new LiteralText(part.getHealth() + "/" + part.getMaxHealth())),
+                            false);
+                    }
                     
-                    source.sendFeedback(new LiteralText("Arms"), false);
-                    Pair<ArmBodyPart, ArmBodyPart> arms = BuiltInParts.getArms(provider);
-                    source.sendFeedback(new LiteralText("- LEFT: " + arms.getLeft().getHealth()), false);
-                    source.sendFeedback(new LiteralText("- RIGHT: " + arms.getRight().getHealth()), false);
-                    
-                    source.sendFeedback(new LiteralText("Legs"), false);
-                    Pair<LegBodyPart, LegBodyPart> legs = BuiltInParts.getLegs(provider);
-                    source.sendFeedback(new LiteralText("- LEFT: " + legs.getLeft().getHealth()), false);
-                    source.sendFeedback(new LiteralText("- RIGHT: " + legs.getRight().getHealth()), false);
-                    
-                    source.sendFeedback(new LiteralText("Feet"), false);
-                    Pair<FootBodyPart, FootBodyPart> feet = BuiltInParts.getFeet(provider);
-                    source.sendFeedback(new LiteralText("- LEFT: " + feet.getLeft().getHealth()), false);
-                    source.sendFeedback(new LiteralText("- RIGHT: " + feet.getRight().getHealth()), false);
                     return 1;
                 })
                     .then(literal("reset").executes(context -> {

--- a/src/main/java/io/github/faecraft/heartshapedbox/main/HSBMain.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/main/HSBMain.java
@@ -1,21 +1,15 @@
 package io.github.faecraft.heartshapedbox.main;
 
-import io.github.faecraft.heartshapedbox.body.BuiltInParts;
-import io.github.faecraft.heartshapedbox.body.impl.ArmBodyPart;
-import io.github.faecraft.heartshapedbox.body.impl.FootBodyPart;
-import io.github.faecraft.heartshapedbox.body.impl.HeadBodyPart;
+import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
+import io.github.faecraft.heartshapedbox.body.BodyPartProvider;
 import io.github.faecraft.heartshapedbox.logic.HSBMiscLogic;
 import io.github.faecraft.heartshapedbox.logic.damage.DamageHandlerDispatcher;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
-import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
-import io.github.faecraft.heartshapedbox.body.BodyPartProvider;
-import io.github.faecraft.heartshapedbox.body.impl.LegBodyPart;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.LiteralText;
-import net.minecraft.util.Pair;
 
 import static net.minecraft.server.command.CommandManager.literal;
 

--- a/src/main/java/io/github/faecraft/heartshapedbox/main/HSBMain.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/main/HSBMain.java
@@ -67,7 +67,7 @@ public class HSBMain implements ModInitializer {
                         ServerCommandSource source = context.getSource();
                         BodyPartProvider provider = (BodyPartProvider)context.getSource().getPlayer();
                         
-                        for (AbstractBodyPart limb : provider.getAll()) {
+                        for (AbstractBodyPart limb : provider.getParts()) {
                             limb.setHealth(limb.getDefaultMaxHealth());
                         }
                         

--- a/src/main/java/io/github/faecraft/heartshapedbox/main/HSBMain.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/main/HSBMain.java
@@ -20,6 +20,8 @@ import net.minecraft.util.Pair;
 import static net.minecraft.server.command.CommandManager.literal;
 
 public class HSBMain implements ModInitializer {
+    public static final String MOD_ID = "heartshapedbox";
+    
     @Override
     public void onInitialize() {
         DamageHandlerDispatcher.registerHandlers();

--- a/src/main/java/io/github/faecraft/heartshapedbox/math/FlexBox.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/math/FlexBox.java
@@ -8,7 +8,7 @@ public class FlexBox {
     public final Quad[] quads = new Quad[6];
     
     // Not the actual center, but a good enough approximation for what its used for
-    public Vec3d roughCenter;
+    public final Vec3d roughCenter;
     
     public FlexBox(Vec3d a, Vec3d b, Vec3d c, Vec3d d, Vec3d e, Vec3d f, Vec3d g, Vec3d h) {
         quads[0] = new Quad(a, b, c, d);

--- a/src/main/java/io/github/faecraft/heartshapedbox/mixin/BodyPartDuck.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/mixin/BodyPartDuck.java
@@ -19,14 +19,13 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.ArrayList;
-import java.util.MissingResourceException;
 import java.util.Optional;
 
 @Mixin(PlayerEntity.class)
 public abstract class BodyPartDuck implements BodyPartProvider {
     private final ArrayList<AbstractBodyPart> parts = new ArrayList<>();
     
-    @Inject(method = "<init>", at = @At("TAIL"))
+    @Inject(method = "<init>*", at = @At("RETURN"))
     public void addPartsOnInit(World world, BlockPos pos, float yaw, GameProfile profile, CallbackInfo ci) {
         parts.add(new HeadBodyPart());
         parts.add(new ArmBodyPart(BodyPartSide.LEFT));
@@ -48,18 +47,18 @@ public abstract class BodyPartDuck implements BodyPartProvider {
     }
     
     @Override
-    public CompoundTag toTag() {
+    public CompoundTag writeToTag() {
         CompoundTag out = new CompoundTag();
         getParts().iterator().forEachRemaining(abstractBodyPart -> abstractBodyPart.toTag(out));
         return out;
     }
     
     @Override
-    public void fromTag(CompoundTag tag) {
+    public void readFromTag(CompoundTag tag) {
         CompoundTag data = tag.getCompound("hsb");
         for (String key : data.getKeys()) {
             Optional<AbstractBodyPart> optional = maybeGet(new Identifier(key));
-            optional.ifPresent(abstractBodyPart -> abstractBodyPart.fromTag(tag.getCompound(key)));
+            optional.ifPresent(abstractBodyPart -> abstractBodyPart.fromTag(data.getCompound(key)));
         }
     }
     

--- a/src/main/java/io/github/faecraft/heartshapedbox/mixin/BodyPartDuck.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/mixin/BodyPartDuck.java
@@ -55,10 +55,9 @@ public abstract class BodyPartDuck implements BodyPartProvider {
     
     @Override
     public void readFromTag(CompoundTag tag) {
-        CompoundTag data = tag.getCompound("hsb");
-        for (String key : data.getKeys()) {
+        for (String key : tag.getKeys()) {
             Optional<AbstractBodyPart> optional = maybeGet(new Identifier(key));
-            optional.ifPresent(abstractBodyPart -> abstractBodyPart.fromTag(data.getCompound(key)));
+            optional.ifPresent(abstractBodyPart -> abstractBodyPart.fromTag(tag.getCompound(key)));
         }
     }
     

--- a/src/main/java/io/github/faecraft/heartshapedbox/mixin/BodyPartDuck.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/mixin/BodyPartDuck.java
@@ -56,7 +56,8 @@ public abstract class BodyPartDuck implements BodyPartProvider {
     
     @Override
     public void fromTag(CompoundTag tag) {
-        for (String key : tag.getKeys()) {
+        CompoundTag data = tag.getCompound("hsb");
+        for (String key : data.getKeys()) {
             Optional<AbstractBodyPart> optional = maybeGet(new Identifier(key));
             optional.ifPresent(abstractBodyPart -> abstractBodyPart.fromTag(tag.getCompound(key)));
         }

--- a/src/main/java/io/github/faecraft/heartshapedbox/mixin/BodyPartDuck.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/mixin/BodyPartDuck.java
@@ -13,6 +13,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -47,6 +48,17 @@ public abstract class BodyPartDuck implements BodyPartProvider {
     }
     
     @Override
+    public @Nullable AbstractBodyPart getOrNull(Identifier identifier) {
+        return maybeGet(identifier).orElse(null);
+    }
+    
+    @Override
+    public AbstractBodyPart getOrThrow(Identifier identifier) {
+        //noinspection OptionalGetWithoutIsPresent
+        return maybeGet(identifier).get();
+    }
+    
+    @Override
     public CompoundTag writeToTag() {
         CompoundTag out = new CompoundTag();
         getParts().iterator().forEachRemaining(abstractBodyPart -> abstractBodyPart.toTag(out));
@@ -59,11 +71,5 @@ public abstract class BodyPartDuck implements BodyPartProvider {
             Optional<AbstractBodyPart> optional = maybeGet(new Identifier(key));
             optional.ifPresent(abstractBodyPart -> abstractBodyPart.fromTag(tag.getCompound(key)));
         }
-    }
-    
-    @Override
-    public AbstractBodyPart getOrThrow(Identifier identifier) {
-        //noinspection OptionalGetWithoutIsPresent
-        return maybeGet(identifier).get();
     }
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/mixin/BodyPartDuck.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/mixin/BodyPartDuck.java
@@ -1,5 +1,6 @@
 package io.github.faecraft.heartshapedbox.mixin;
 
+import com.mojang.authlib.GameProfile;
 import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
 import io.github.faecraft.heartshapedbox.body.BodyPartProvider;
 import io.github.faecraft.heartshapedbox.body.BodyPartSide;
@@ -9,78 +10,42 @@ import io.github.faecraft.heartshapedbox.body.impl.HeadBodyPart;
 import io.github.faecraft.heartshapedbox.body.impl.LegBodyPart;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.Pair;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.ArrayList;
 
 @Mixin(PlayerEntity.class)
 public abstract class BodyPartDuck implements BodyPartProvider {
-    public HeadBodyPart head = new HeadBodyPart();
+    private final ArrayList<AbstractBodyPart> parts = new ArrayList<>();
     
-    public ArmBodyPart leftArm = new ArmBodyPart(BodyPartSide.LEFT);
-    public ArmBodyPart rightArm = new ArmBodyPart(BodyPartSide.RIGHT);
-    
-    public LegBodyPart leftLeg = new LegBodyPart(BodyPartSide.LEFT);
-    public LegBodyPart rightLeg = new LegBodyPart(BodyPartSide.RIGHT);
-    
-    public FootBodyPart leftFoot = new FootBodyPart(BodyPartSide.LEFT);
-    public FootBodyPart rightFoot = new FootBodyPart(BodyPartSide.RIGHT);
-    
-    @Override
-    public HeadBodyPart getHead() {
-        return head;
+    @Inject(method = "<init>", at = @At("HEAD"))
+    public void addPartsOnInit(World world, BlockPos pos, float yaw, GameProfile profile, CallbackInfo ci) {
+        parts.add(new HeadBodyPart());
+        parts.add(new ArmBodyPart(BodyPartSide.LEFT));
+        parts.add(new ArmBodyPart(BodyPartSide.RIGHT));
+        parts.add(new LegBodyPart(BodyPartSide.LEFT));
+        parts.add(new LegBodyPart(BodyPartSide.RIGHT));
+        parts.add(new FootBodyPart(BodyPartSide.LEFT));
+        parts.add(new FootBodyPart(BodyPartSide.RIGHT));
     }
     
     @Override
-    public Pair<ArmBodyPart, ArmBodyPart> getArms() {
-        return new Pair<>(leftArm, rightArm);
-    }
-    
-    @Override
-    public Pair<LegBodyPart, LegBodyPart> getLegs() {
-        return new Pair<>(leftLeg, rightLeg);
-    }
-    
-    @Override
-    public Pair<FootBodyPart, FootBodyPart> getFeet() {
-        return new Pair<>(leftFoot, rightFoot);
-    }
-    
-    @Override
-    public ArrayList<AbstractBodyPart> getAll() {
-        ArrayList<AbstractBodyPart> out = new ArrayList<>();
-        out.add(head);
-        out.add(leftArm);
-        out.add(rightArm);
-        out.add(leftLeg);
-        out.add(rightLeg);
-        out.add(leftFoot);
-        out.add(rightFoot);
-        return out;
+    public ArrayList<AbstractBodyPart> getParts() {
+        return parts;
     }
     
     @Override
     public ArrayList<AbstractBodyPart> stateCopy() {
-        ArrayList<AbstractBodyPart> out = new ArrayList<>();
-        out.add(head.copyInto(new HeadBodyPart()));
-        out.add(leftArm.copyInto(new ArmBodyPart(BodyPartSide.LEFT)));
-        out.add(rightArm.copyInto(new ArmBodyPart(BodyPartSide.RIGHT)));
-        out.add(leftLeg.copyInto(new LegBodyPart(BodyPartSide.LEFT)));
-        out.add(rightLeg.copyInto(new LegBodyPart(BodyPartSide.RIGHT)));
-        out.add(leftFoot.copyInto(new FootBodyPart(BodyPartSide.LEFT)));
-        out.add(rightFoot.copyInto(new FootBodyPart(BodyPartSide.RIGHT)));
-        return out;
+        return null;
     }
     
     @Override
-    public void setFrom(ArrayList<AbstractBodyPart> state) {
-        // TODO: Refactor this! It assumes fixed input order
-        head = (HeadBodyPart)state.get(0);
-        leftArm = (ArmBodyPart)state.get(1);
-        rightArm = (ArmBodyPart)state.get(2);
-        leftLeg = (LegBodyPart)state.get(3);
-        rightLeg = (LegBodyPart)state.get(4);
-        leftFoot = (FootBodyPart)state.get(5);
-        rightFoot = (FootBodyPart)state.get(6);
+    public void setStateFrom(ArrayList<AbstractBodyPart> provider) {
+    
     }
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/mixin/BodyPartDuck.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/mixin/BodyPartDuck.java
@@ -4,6 +4,7 @@ import com.mojang.authlib.GameProfile;
 import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
 import io.github.faecraft.heartshapedbox.body.BodyPartProvider;
 import io.github.faecraft.heartshapedbox.body.BodyPartSide;
+import io.github.faecraft.heartshapedbox.body.BuiltInParts;
 import io.github.faecraft.heartshapedbox.body.impl.ArmBodyPart;
 import io.github.faecraft.heartshapedbox.body.impl.FootBodyPart;
 import io.github.faecraft.heartshapedbox.body.impl.HeadBodyPart;
@@ -20,36 +21,42 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Optional;
 
 @Mixin(PlayerEntity.class)
 public abstract class BodyPartDuck implements BodyPartProvider {
-    private final ArrayList<AbstractBodyPart> parts = new ArrayList<>();
+    private final HashMap<Identifier, AbstractBodyPart> parts = new HashMap<>();
     
     @Inject(method = "<init>*", at = @At("RETURN"))
     public void addPartsOnInit(World world, BlockPos pos, float yaw, GameProfile profile, CallbackInfo ci) {
-        parts.add(new HeadBodyPart());
-        parts.add(new ArmBodyPart(BodyPartSide.LEFT));
-        parts.add(new ArmBodyPart(BodyPartSide.RIGHT));
-        parts.add(new LegBodyPart(BodyPartSide.LEFT));
-        parts.add(new LegBodyPart(BodyPartSide.RIGHT));
-        parts.add(new FootBodyPart(BodyPartSide.LEFT));
-        parts.add(new FootBodyPart(BodyPartSide.RIGHT));
+        parts.put(BuiltInParts.HEAD, new HeadBodyPart());
+        parts.put(BuiltInParts.LEFT_ARM, new ArmBodyPart(BodyPartSide.LEFT));
+        parts.put(BuiltInParts.RIGHT_ARM, new ArmBodyPart(BodyPartSide.RIGHT));
+        parts.put(BuiltInParts.LEFT_LEG, new LegBodyPart(BodyPartSide.LEFT));
+        parts.put(BuiltInParts.RIGHT_LEG, new LegBodyPart(BodyPartSide.RIGHT));
+        parts.put(BuiltInParts.LEFT_FOOT, new FootBodyPart(BodyPartSide.LEFT));
+        parts.put(BuiltInParts.RIGHT_FOOT, new FootBodyPart(BodyPartSide.RIGHT));
     }
     
     @Override
-    public ArrayList<AbstractBodyPart> getParts() {
+    public HashMap<Identifier, AbstractBodyPart> getPartsMap() {
         return parts;
     }
     
     @Override
+    public ArrayList<AbstractBodyPart> getParts() {
+        return new ArrayList<>(parts.values());
+    }
+    
+    @Override
     public Optional<AbstractBodyPart> maybeGet(Identifier identifier) {
-        return parts.stream().filter(abstractBodyPart -> abstractBodyPart.getIdentifier().equals(identifier)).findFirst();
+        return Optional.ofNullable(parts.get(identifier));
     }
     
     @Override
     public @Nullable AbstractBodyPart getOrNull(Identifier identifier) {
-        return maybeGet(identifier).orElse(null);
+        return parts.get(identifier);
     }
     
     @Override

--- a/src/main/java/io/github/faecraft/heartshapedbox/mixin/BodyPartDuck.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/mixin/BodyPartDuck.java
@@ -9,7 +9,8 @@ import io.github.faecraft.heartshapedbox.body.impl.FootBodyPart;
 import io.github.faecraft.heartshapedbox.body.impl.HeadBodyPart;
 import io.github.faecraft.heartshapedbox.body.impl.LegBodyPart;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.util.Pair;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
@@ -18,6 +19,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.ArrayList;
+import java.util.Optional;
 
 @Mixin(PlayerEntity.class)
 public abstract class BodyPartDuck implements BodyPartProvider {
@@ -40,12 +42,19 @@ public abstract class BodyPartDuck implements BodyPartProvider {
     }
     
     @Override
-    public ArrayList<AbstractBodyPart> stateCopy() {
-        return null;
+    public Optional<AbstractBodyPart> getFromIdentifier(Identifier identifier) {
+        return parts.stream().filter(abstractBodyPart -> abstractBodyPart.getIdentifier().equals(identifier)).findFirst();
     }
     
     @Override
-    public void setStateFrom(ArrayList<AbstractBodyPart> provider) {
+    public CompoundTag toTag() {
+        CompoundTag out = new CompoundTag();
+        getParts().iterator().forEachRemaining(abstractBodyPart -> abstractBodyPart.toTag(out));
+        return out;
+    }
+    
+    @Override
+    public void fromTag(CompoundTag tag) {
     
     }
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/mixin/ManageLivingEntityDamageLogicMixin.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/mixin/ManageLivingEntityDamageLogicMixin.java
@@ -8,6 +8,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(LivingEntity.class)
 public class ManageLivingEntityDamageLogicMixin {
+    @SuppressWarnings("SameReturnValue")
     @Redirect(method = "damage", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"))
     public boolean disableFallingBlockDamageLogic(ItemStack itemStack) {
         return true;

--- a/src/main/java/io/github/faecraft/heartshapedbox/mixin/ManageTakenDamageMixin.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/mixin/ManageTakenDamageMixin.java
@@ -10,7 +10,6 @@ import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(PlayerEntity.class)
 public abstract class ManageTakenDamageMixin extends LivingEntity {

--- a/src/main/java/io/github/faecraft/heartshapedbox/mixin/SaveDamageMixin.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/mixin/SaveDamageMixin.java
@@ -2,12 +2,17 @@ package io.github.faecraft.heartshapedbox.mixin;
 
 import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
 import io.github.faecraft.heartshapedbox.body.BodyPartProvider;
+import net.fabricmc.fabric.api.util.NbtType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Optional;
 
 @Mixin(PlayerEntity.class)
 public class SaveDamageMixin {
@@ -17,9 +22,7 @@ public class SaveDamageMixin {
         
         CompoundTag partsTag = new CompoundTag();
     
-        for (AbstractBodyPart limb : provider.getAll()) {
-            limb.toTag(partsTag);
-        }
+        partsTag.put("hsb", provider.toTag());
         
         tag.put("hsb", partsTag);
     }
@@ -30,8 +33,9 @@ public class SaveDamageMixin {
         
         CompoundTag partsTag = tag.getCompound("hsb");
     
-        for (AbstractBodyPart limb : provider.getAll()) {
-            limb.fromTag(partsTag);
+        for (String key : partsTag.getKeys()) {
+            Optional<AbstractBodyPart> optional = provider.getFromIdentifier(new Identifier(key));
+            optional.ifPresent(abstractBodyPart -> abstractBodyPart.fromTag(partsTag.getCompound(key)));
         }
     }
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/mixin/SaveDamageMixin.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/mixin/SaveDamageMixin.java
@@ -1,18 +1,12 @@
 package io.github.faecraft.heartshapedbox.mixin;
 
-import io.github.faecraft.heartshapedbox.body.AbstractBodyPart;
 import io.github.faecraft.heartshapedbox.body.BodyPartProvider;
-import net.fabricmc.fabric.api.util.NbtType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.Optional;
 
 @Mixin(PlayerEntity.class)
 public class SaveDamageMixin {
@@ -33,9 +27,6 @@ public class SaveDamageMixin {
         
         CompoundTag partsTag = tag.getCompound("hsb");
     
-        for (String key : partsTag.getKeys()) {
-            Optional<AbstractBodyPart> optional = provider.getFromIdentifier(new Identifier(key));
-            optional.ifPresent(abstractBodyPart -> abstractBodyPart.fromTag(partsTag.getCompound(key)));
-        }
+        provider.fromTag(partsTag);
     }
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/mixin/SaveDamageMixin.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/mixin/SaveDamageMixin.java
@@ -14,7 +14,7 @@ public class SaveDamageMixin {
     public void serializeBodyParts(CompoundTag tag, CallbackInfo ci) {
         BodyPartProvider provider = (BodyPartProvider)this;
     
-        tag.put("hsb", provider.toTag());
+        tag.put("hsb", provider.writeToTag());
     }
     
     @Inject(method = "readCustomDataFromTag", at = @At("RETURN"))
@@ -23,6 +23,6 @@ public class SaveDamageMixin {
         
         CompoundTag partsTag = tag.getCompound("hsb");
     
-        provider.fromTag(partsTag);
+        provider.readFromTag(partsTag);
     }
 }

--- a/src/main/java/io/github/faecraft/heartshapedbox/mixin/SaveDamageMixin.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/mixin/SaveDamageMixin.java
@@ -1,6 +1,7 @@
 package io.github.faecraft.heartshapedbox.mixin;
 
 import io.github.faecraft.heartshapedbox.body.BodyPartProvider;
+import io.github.faecraft.heartshapedbox.main.HSBMain;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundTag;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,14 +15,14 @@ public class SaveDamageMixin {
     public void serializeBodyParts(CompoundTag tag, CallbackInfo ci) {
         BodyPartProvider provider = (BodyPartProvider)this;
     
-        tag.put("hsb", provider.writeToTag());
+        tag.put(HSBMain.MOD_ID, provider.writeToTag());
     }
     
     @Inject(method = "readCustomDataFromTag", at = @At("RETURN"))
     public void deserializeBodyParts(CompoundTag tag, CallbackInfo ci) {
         BodyPartProvider provider = (BodyPartProvider)this;
         
-        CompoundTag partsTag = tag.getCompound("hsb");
+        CompoundTag partsTag = tag.getCompound(HSBMain.MOD_ID);
     
         provider.readFromTag(partsTag);
     }

--- a/src/main/java/io/github/faecraft/heartshapedbox/mixin/SaveDamageMixin.java
+++ b/src/main/java/io/github/faecraft/heartshapedbox/mixin/SaveDamageMixin.java
@@ -13,12 +13,8 @@ public class SaveDamageMixin {
     @Inject(method = "writeCustomDataToTag", at = @At("RETURN"))
     public void serializeBodyParts(CompoundTag tag, CallbackInfo ci) {
         BodyPartProvider provider = (BodyPartProvider)this;
-        
-        CompoundTag partsTag = new CompoundTag();
     
-        partsTag.put("hsb", provider.toTag());
-        
-        tag.put("hsb", partsTag);
+        tag.put("hsb", provider.toTag());
     }
     
     @Inject(method = "readCustomDataFromTag", at = @At("RETURN"))

--- a/src/main/resources/heartshapedbox.mixins.json
+++ b/src/main/resources/heartshapedbox.mixins.json
@@ -9,7 +9,7 @@
     "ManageTakenDamageMixin",
     "SaveDamageMixin",
     "damage_invoke.PlayerEntityDamageBypass",
-    "damage_invoke.ServerPlayerEntityDamageBypass",
+    "damage_invoke.ServerPlayerEntityDamageBypass"
   ],
   "client": [
   ],


### PR DESCRIPTION
Rewrites parts to be identifier based
- All parts are stored in a single ArrayList
- Limbs and providers can be (fairly) easily serialized to and from tags
- There is a class with lenses/getters for the default limbs
- FlexBox updating still needs to be rewritten to better support dynamic parts, but works in its current state